### PR TITLE
Enable paths with spaces for cutouts

### DIFF
--- a/transyto/transyto.py
+++ b/transyto/transyto.py
@@ -642,7 +642,7 @@ class TimeSeriesAnalysis:
         """
 
         # Output directory for all the cutouts
-        output_directory = self._data_directory + f'{star_id}_Cutouts'
+        output_directory = f'"{self._data_directory}{star_id}_Cutouts"'
         os.makedirs(output_directory, exist_ok=True)
 
         if filename.endswith('.fz'):


### PR DESCRIPTION
Previously threw an error when making cutouts, due to providing invalid arguments when paths had spaces. This change simply encases the path in double quotes to make sure it is read as a single string and not multiple arguments.