### PR TITLE
A clarification in the readout_noise

### DIFF
--- a/transyto/noise/__init__.py
+++ b/transyto/noise/__init__.py
@@ -66,7 +66,7 @@ def compute_noises(gain, exptime, target_flux_sec, target_background_sec,
                                                          * gain * exptime)) / target_signal)
 
     # Sigma readout noise
-    readout_noise = (pixel_readout * aperture_radius)**2 * np.pi
+    readout_noise = (pixel_readout) * (aperture_radius)**2 * np.pi
     sigma_readout = -2.5 * np.log10((target_signal - np.sqrt(readout_noise)) / target_signal)
 
     Outputs = namedtuple('Outputs', 'sigma_photon sigma_sky sigma_readout')


### PR DESCRIPTION
If my understanding is correct, The readout noise is pixel_readout times the area of the aperture in pixel units? or is it something different? 